### PR TITLE
Hash messages before storage in certain channels

### DIFF
--- a/src/plugins/r9k/r9k.js
+++ b/src/plugins/r9k/r9k.js
@@ -1,5 +1,9 @@
 const persistence = require('./persistence');
 
+const HASH_CHANNELS = [
+  '361699287966416907',
+];
+
 exports.init = (app) => {
   persistence.init((error) => {
     if (error) {
@@ -44,7 +48,9 @@ exports.init = (app) => {
         return;
       }
 
-      persistence.checkMessage(message, () => {
+      const shouldHash = HASH_CHANNELS.includes(channelId);
+
+      persistence.checkMessage(message, shouldHash, () => {
         console.log(`message exists: ${message}`);
 
         // TODO: Add support for delete reason in the audit log once discord.io adds support


### PR DESCRIPTION
This feature can be used for increased privacy and also if you don't
want to use your logs for training markov chains.

Closes #24 